### PR TITLE
Trocando nome do menu Development para Dashboard

### DIFF
--- a/resources/js/Layouts/AppLayout.vue
+++ b/resources/js/Layouts/AppLayout.vue
@@ -49,7 +49,7 @@ const logout = () => {
                             <!-- Navigation Links -->
                             <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
                                 <NavLink :href="route('dashboard')" :active="route().current('dashboard')">
-                                    Development
+                                    Dashboard
                                 </NavLink>
                                 <NavLink :href="route('admin.posts.index')" :active="route().current('admin.posts.*')">
                                     Post


### PR DESCRIPTION
O nome do menu estava errado. Estava como Development mas o correto e Dashboard.